### PR TITLE
Set preferUnplugged to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
     "plugin",
     "transformer"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "preferUnplugged": true
 }


### PR DESCRIPTION
When using Yarn, the package is installed through Yarn PnP. This causes it to be stored in a zip, using either virtual folders or a zip filesystem. Because this is a compiled `wasm` plugin, and swc does not have support for loading plugins from the zipfs, the plugin fails to load when used with an obscured error.

The local workaround was to use `yarn unplug` which saves a `dependenciesMeta` field to the project package.json, but that is obviously not ideal, considering the plugin shouldn't work in any cases in which it uses PnP and it should be unplugged by default.

See https://yarnpkg.com/configuration/manifest#preferUnplugged for the docs on this package.json property.